### PR TITLE
added functional tests

### DIFF
--- a/netconnect/juniper/tests/test_juniper_driver_functional.py
+++ b/netconnect/juniper/tests/test_juniper_driver_functional.py
@@ -1,0 +1,68 @@
+import pytest
+import pexpect
+
+from netconnect.juniper.juniper_driver import JuniperDriver
+
+
+run_tests = False
+
+@pytest.fixture()
+def setup_juniper_driver():
+    dev = JuniperDriver(device='10.1.1.70', username='lab', password='Password')
+    return dev
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_login_with_correct_details_succeeds(setup_juniper_driver):
+    setup_juniper_driver.login()
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_login_with_incorrect_password_fails():
+    dev = JuniperDriver(device='10.1.1.72', username='lab', password='wrong', timeout=3)
+    with pytest.raises(pexpect.TIMEOUT):
+        dev.login()
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_login_with_incorrect_username_fails():
+    dev = JuniperDriver(device='10.1.1.72', username='wrong', password='Password', timeout=3)
+    with pytest.raises(pexpect.TIMEOUT):
+        dev.login()
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_get_prompt_returns_correct_prompt(setup_juniper_driver):
+    setup_juniper_driver.login()
+    assert setup_juniper_driver.get_prompt() == 'lab@lab-vmx-01>'
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_disable_paging_returns_true(setup_juniper_driver):
+    setup_juniper_driver.login()
+    assert setup_juniper_driver.disable_paging() is True
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_configuration_mode_true(setup_juniper_driver):
+    setup_juniper_driver.login()
+    assert setup_juniper_driver.disable_paging() is True
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_save_config_returns_true(setup_juniper_driver):
+    setup_juniper_driver.login()
+    assert setup_juniper_driver.configuration_mode() is True
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_enable_api_with_configuration_mode_returns_true(setup_juniper_driver):
+    setup_juniper_driver.login()
+    setup_juniper_driver.configuration_mode()
+    assert setup_juniper_driver.enable_api() is True
+
+
+@pytest.mark.skipif(not run_tests, reason='test requires juniper device')
+def test_enable_api_without_configuration_mode_returns_true(setup_juniper_driver):
+    setup_juniper_driver.login()
+    assert setup_juniper_driver.enable_api() is True


### PR DESCRIPTION
```bash
=================================================================== test session starts ====================================================================
platform linux -- Python 3.5.2, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/bsearle/envs/netconnect-test/netconnect-env/bin/python3.5
cachedir: netconnect/.cache
rootdir: /home/bsearle/git-repos/netconnect, inifile: 
plugins: cov-2.3.1
collected 44 items 

netconnect/netconnect/arista/tests/test_arista_driver.py::test_setup_arista_driver_is_a_arista_driver_object PASSED
netconnect/netconnect/arista/tests/test_arista_driver_functional.py::test_enable_api_returns_true PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver.py::test_setup_cisco_driver_is_a_cisco_driver_object PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver.py::test_disable_paging_returns_true PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_login_with_correct_details_succeeds PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_login_with_incorrect_password_fails PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_login_with_incorrect_username_fails PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_login_with_correct_details_and_no_enable_password_raises_value_error PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_get_prompt_returns_correct_prompt PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_disable_paging_returns_true PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_save_config_returns_true PASSED
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py::test_configuration_mode_returns_true PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver.py::test_setup_juniper_driver_is_a_juniper_driver_object PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_login_with_correct_details_succeeds PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_login_with_incorrect_password_fails PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_login_with_incorrect_username_fails PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_get_prompt_returns_correct_prompt PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_disable_paging_returns_true PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_configuration_mode_true PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_save_config_returns_true PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_enable_api_with_configuration_mode_returns_true PASSED
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py::test_enable_api_without_configuration_mode_returns_true PASSED
netconnect/netconnect/unix/tests/test_unix_login.py::test_setup_unix_driver_is_a_unix_driver_object PASSED
netconnect/tests/test_base.py::test_base_login_password PASSED
netconnect/tests/test_base.py::test_base_login_timeout PASSED
netconnect/tests/test_base.py::test_base_login_device PASSED
netconnect/tests/test_base.py::test_base_login_ssh_port PASSED
netconnect/tests/test_base.py::test_base_login_host_key_checking PASSED
netconnect/tests/test_base.py::test_base_login_options_with_ssh_key_file_ssh_driver_syntax PASSED
netconnect/tests/test_base.py::test_base_login_with_no_port_ssh_driver_syntax PASSED
netconnect/tests/test_base.py::test_base_login_instantiation_is_a_connector_object PASSED
netconnect/tests/test_base.py::test_base_login_options_username_password_ssh_driver_syntax PASSED
netconnect/tests/test_base.py::test_telnet_driver_syntax PASSED
netconnect/tests/test_base.py::test_base_login_with_ssh_config_file_and_ignore_ssh_config_raises_attribute_error PASSED
netconnect/tests/test_base.py::test_base_login_with_ssh_config_file_and_ignore_ssh_config_attribute_error_message PASSED
netconnect/tests/test_base.py::test_base_login_with_defaults_matches_ssh_driver_syntax PASSED
netconnect/tests/test_base.py::test_base_login_options_ssh_config_file_and_ignore_ssh_config_ssh_driver_syntax PASSED
netconnect/tests/test_helpers.py::test_parse_error_raises_eof PASSED
netconnect/tests/test_helpers.py::test_parse_error_eof_message PASSED
netconnect/tests/test_helpers.py::test_parse_error_raises_timeout PASSED
netconnect/tests/test_helpers.py::test_parse_error_timeout_message PASSED
netconnect/tests/test_helpers.py::test_validate_login_type_raises_value_error PASSED
netconnect/tests/test_helpers.py::test_validate_login_type_with_telnet_does_not_raise_value_error PASSED
netconnect/tests/test_helpers.py::test_validate_login_type_with_ssh_does_not_raise_value_error PASSED

----------- coverage: platform linux, python 3.5.2-final-0 -----------
Name                                                                    Stmts   Miss  Cover
-------------------------------------------------------------------------------------------
netconnect/netconnect/__init__.py                                           0      0   100%
netconnect/netconnect/arista/__init__.py                                    0      0   100%
netconnect/netconnect/arista/arista_driver.py                               7      0   100%
netconnect/netconnect/arista/tests/__init__.py                              0      0   100%
netconnect/netconnect/arista/tests/test_arista_driver.py                    7      0   100%
netconnect/netconnect/arista/tests/test_arista_driver_functional.py        10      0   100%
netconnect/netconnect/base.py                                              32      0   100%
netconnect/netconnect/cisco/__init__.py                                     0      0   100%
netconnect/netconnect/cisco/cisco_driver.py                                99     25    75%
netconnect/netconnect/cisco/tests/__init__.py                               0      0   100%
netconnect/netconnect/cisco/tests/test_cisco_driver.py                     13      0   100%
netconnect/netconnect/cisco/tests/test_cisco_driver_functional.py          32      0   100%
netconnect/netconnect/helpers.py                                           53     16    70%
netconnect/netconnect/juniper/__init__.py                                   0      0   100%
netconnect/netconnect/juniper/juniper_driver.py                            87     29    67%
netconnect/netconnect/juniper/tests/__init__.py                             0      0   100%
netconnect/netconnect/juniper/tests/test_juniper_driver.py                  7      0   100%
netconnect/netconnect/juniper/tests/test_juniper_driver_functional.py      36      0   100%
netconnect/netconnect/unix/__init__.py                                      0      0   100%
netconnect/netconnect/unix/tests/__init__.py                                0      0   100%
netconnect/netconnect/unix/tests/test_unix_login.py                         7      0   100%
netconnect/netconnect/unix/unix_driver.py                                  25     18    28%
netconnect/setup.py                                                         6      6     0%
netconnect/tests/__init__.py                                                0      0   100%
netconnect/tests/test_base.py                                              44      1    98%
netconnect/tests/test_helpers.py                                           24      2    92%
-------------------------------------------------------------------------------------------
TOTAL                                                                     489     97    80%


================================================================ 44 passed in 48.54 seconds ================================================================
```